### PR TITLE
adicionado botão de configurações, redireciona para escolher novas op

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,7 @@
         <h1 id="popup-title">ED Help</h1>
         <img src="Duda.png" class="duda">
 
+        <div id="config-button-container"></div>
         <div id="change-op-button-container"></div>
     </div>
 

--- a/popup.js
+++ b/popup.js
@@ -118,6 +118,34 @@ function renderizarModais(dadosAgrupados) {
 }
 */
 
+function renderizarBotaoDeConfiguracoes(){
+    const container = document.getElementById('config-button-container');
+    if (!container) return;
+
+    const button = document.createElement('button');
+    button.className = 'change-op-button';
+    button.title = 'Configurações';
+    button.innerHTML = '⚙️';
+
+    button.addEventListener('click', () => {
+
+            chrome.storage.local.remove(['operacoesSelecionadas'], () => {
+            console.log("Operações selecionadas limpas do local storage.");
+            
+            chrome.storage.session.remove(['operacaoAtivaId'], () => {
+            console.log("Operação ativa da sessão limpa.");
+                
+            window.location.href = 'onboarding.html'; 
+            });
+        });
+    });
+
+    container.appendChild(button);
+
+    
+}
+
+
 // Nova função para renderizar o botão de troca de operação
 function renderizarBotaoDeTroca(totalOperacoesSalvas) {
     // Se o usuário só tem 1 (ou menos) operação salva, não faz nada.
@@ -170,6 +198,7 @@ function configurarEventListeners() {
 }
 
 async function iniciarPopup() {
+    renderizarBotaoDeConfiguracoes();
     
     let sessionData = await chrome.storage.session.get(['operacaoAtivaId']);
     let operacaoId = sessionData.operacaoAtivaId;

--- a/style.css
+++ b/style.css
@@ -156,3 +156,12 @@ button:hover {
   right: 0; /* botão gruda no lado direito */
 
 }
+
+#config-button-container{
+  position: absolute;
+  right: 40x; 
+}
+
+#operacaoSelect{
+  color: white
+}


### PR DESCRIPTION
foi adicionado no popup um botão de configurações, com ele é possível apagar o histórico de seleção local e voltar para a página de onboarding para escolher novas operações.